### PR TITLE
fix: Disable scroll on wrapper page to prevent scrollbounce iOS

### DIFF
--- a/lib/assets/index.html
+++ b/lib/assets/index.html
@@ -8,6 +8,7 @@
         width: 100%;
         height: 100%;
         margin: 0;
+        overflow: hidden;
       }
     </style>
     <script>


### PR DESCRIPTION
On iOS when pulling the page down from either the chat header or the message area the page will have a scroll bounce. This is unwanted behavior since this will break the illusion that the chatbox is contained inside the app. 

To prevent this I have disabled the scrolling for the wrapper by setting the overflow to hidden for the html/body. 

To fully prevent this behavior it is also necessary to disable the scrolling inside the iframe used to contain the chat. This can be done by adding the following css to the theme used by your app in the theme editor. 

```
html,
body {
  height: 100%;
  width: 100%;
  overflow: hidden;
}
```
For our project I added this part to the css of the ChatHeader in the theme
 