### PR TITLE
Update the deprecated hashing functions.

### DIFF
--- a/lib/src/chatoptions.dart
+++ b/lib/src/chatoptions.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:ui';
 
 import './chatbox.dart';
 
@@ -101,7 +100,7 @@ class MessageFieldOptions {
     return true;
   }
 
-  int get hashCode => hashValues(autofocus, enterSendsMessage, placeholder, spellcheck);
+  int get hashCode => Object.hash(autofocus, enterSendsMessage, placeholder, spellcheck);
 }
 
 /// The possible values for showTranslationToggle
@@ -253,7 +252,7 @@ class ChatBoxOptions {
     return true;
   }
 
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
     dir,
     messageField,
     showChatHeader,

--- a/lib/src/conversation.dart
+++ b/lib/src/conversation.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/foundation.dart';
 
 import './session.dart';
@@ -76,7 +74,7 @@ class Participant {
     return true;
   }
 
-  int get hashCode => hashValues(user, access, notify);
+  int get hashCode => Object.hash(user, access, notify);
 }
 
 /// This represents a conversation that is about to be created, fetched, or
@@ -201,13 +199,13 @@ class Conversation extends _BaseConversation {
     return true;
   }
 
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
     _session,
-    hashList(participants),
+    Object.hashAll(participants),
     id,
-    (custom != null ? hashList(custom!.keys) : custom),
-    (custom != null ? hashList(custom!.values) : custom),
-    (welcomeMessages != null ? hashList(welcomeMessages) : welcomeMessages),
+    (custom != null ? Object.hashAll(custom!.keys) : custom),
+    (custom != null ? Object.hashAll(custom!.values) : custom),
+    (welcomeMessages != null ? Object.hashAll(welcomeMessages!) : welcomeMessages),
     photoUrl,
     subject,
   );

--- a/lib/src/predicate.dart
+++ b/lib/src/predicate.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
@@ -63,10 +62,10 @@ class FieldPredicate<T> {
     return true;
   }
 
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
     _operand,
     _value,
-    (_values != null ? hashList(_values) : _values),
+    (_values != null ? Object.hashAll(_values!) : _values),
   );
 }
 
@@ -121,10 +120,10 @@ class CustomFieldPredicate extends FieldPredicate<String> {
     return true;
   }
 
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
     _operand,
     _value,
-    (_values != null ? hashList(_values) : _values),
+    (_values != null ? Object.hashAll(_values!) : _values),
     _exists,
   );
 }
@@ -206,10 +205,10 @@ class ConversationPredicate {
     return true;
   }
 
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
     access,
-    (custom != null ? hashList(custom!.keys) : custom),
-    (custom != null ? hashList(custom!.values) : custom),
+    (custom != null ? Object.hashAll(custom!.keys) : custom),
+    (custom != null ? Object.hashAll(custom!.values) : custom),
     hasUnreadMessages,
   );
 }
@@ -309,10 +308,10 @@ class SenderPredicate {
     return true;
   }
 
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
     id,
-    (custom != null ? hashList(custom!.keys) : custom),
-    (custom != null ? hashList(custom!.values) : custom),
+    (custom != null ? Object.hashAll(custom!.keys) : custom),
+    (custom != null ? Object.hashAll(custom!.values) : custom),
     locale,
     role,
   );
@@ -395,9 +394,9 @@ class MessagePredicate {
     return true;
   }
 
-  int get hashCode => hashValues(
-    (custom != null ? hashList(custom!.keys) : custom),
-    (custom != null ? hashList(custom!.values) : custom),
+  int get hashCode => Object.hash(
+    (custom != null ? Object.hashAll(custom!.keys) : custom),
+    (custom != null ? Object.hashAll(custom!.values) : custom),
     origin,
     sender,
     type,

--- a/lib/src/user.dart
+++ b/lib/src/user.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
@@ -232,14 +231,14 @@ class User extends _BaseUser {
     return true;
   }
 
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
     _session,
     _idOnly,
     availabilityText,
-    (custom != null ? hashList(custom!.keys) : custom),
-    (custom != null ? hashList(custom!.values) : custom),
-    (email != null ? hashList(email) : email),
-    (phone != null ? hashList(phone) : phone),
+    (custom != null ? Object.hashAll(custom!.keys) : custom),
+    (custom != null ? Object.hashAll(custom!.values) : custom),
+    (email != null ? Object.hashAll(email!) : email),
+    (phone != null ? Object.hashAll(phone!) : phone),
     id,
     name,
     locale,


### PR DESCRIPTION
Just for context: Dart considers 2 objects to be equal if they point to the same memory location, unless you override the operator ==. The only problem is that if you override the operator ==, Dart requires you to override the hashCode as well.