### PR TITLE
overrideUrlLoading param added to chatbox

### DIFF
--- a/lib/src/chatbox.dart
+++ b/lib/src/chatbox.dart
@@ -20,10 +20,12 @@ import './predicate.dart';
 import './webview_common.dart';
 
 typedef SendMessageHandler = void Function(SendMessageEvent event);
-typedef TranslationToggledHandler = void Function(TranslationToggledEvent event);
+typedef TranslationToggledHandler = void Function(
+    TranslationToggledEvent event);
 typedef LoadingStateHandler = void Function(LoadingState state);
 typedef MessageActionHandler = void Function(MessageActionEvent event);
-typedef NavigationHandler = UrlNavigationAction Function(UrlNavigationRequest navigationRequest);
+typedef NavigationHandler = UrlNavigationAction Function(
+    UrlNavigationRequest navigationRequest);
 
 class SendMessageEvent {
   final ConversationData conversation;
@@ -31,9 +33,9 @@ class SendMessageEvent {
   final SentMessage message;
 
   SendMessageEvent.fromJson(Map<String, dynamic> json)
-    : conversation = ConversationData.fromJson(json['conversation']),
-    me = UserData.fromJson(json['me']),
-    message = SentMessage.fromJson(json['message']);
+      : conversation = ConversationData.fromJson(json['conversation']),
+        me = UserData.fromJson(json['me']),
+        message = SentMessage.fromJson(json['message']);
 }
 
 class TranslationToggledEvent {
@@ -41,8 +43,8 @@ class TranslationToggledEvent {
   final bool isEnabled;
 
   TranslationToggledEvent.fromJson(Map<String, dynamic> json)
-    : conversation = ConversationData.fromJson(json['conversation']),
-    isEnabled = json['isEnabled'];
+      : conversation = ConversationData.fromJson(json['conversation']),
+        isEnabled = json['isEnabled'];
 }
 
 enum LoadingState { loading, loaded }
@@ -52,8 +54,8 @@ class MessageActionEvent {
   final Message message;
 
   MessageActionEvent.fromJson(Map<String, dynamic> json)
-    : action = json['action'],
-    message = Message.fromJson(json['message']);
+      : action = json['action'],
+        message = Message.fromJson(json['message']);
 }
 
 class UrlNavigationRequest {
@@ -81,6 +83,7 @@ class ChatBox extends StatefulWidget {
   final TranslateConversations? translateConversations;
   final List<String> highlightedWords = const <String>[];
   final MessagePredicate messageFilter;
+  final Future<bool> Function(Uri uri)? overrideUrlLoading;
 
   final Conversation? conversation;
   final bool? asGuest;
@@ -101,6 +104,7 @@ class ChatBox extends StatefulWidget {
     this.translateConversations,
     //this.highlightedWords = const <String>[], // Commented out due to bug #1953
     this.messageFilter = const MessagePredicate(),
+    this.overrideUrlLoading,
     this.conversation,
     this.asGuest,
     this.onSendMessage,
@@ -171,12 +175,16 @@ class ChatBoxState extends State<ChatBox> {
         }
       ''');
 
-      createSession(execute: execute, session: widget.session, variableName: getUserVariableName(widget.session.me));
+      createSession(
+          execute: execute,
+          session: widget.session,
+          variableName: getUserVariableName(widget.session.me));
       _createChatBox();
       // messageFilter and highlightedWords are set as options for the chatbox
       _createConversation();
 
-      execute('chatBox.mount(document.getElementById("talkjs-container")).then(() => window.flutter_inappwebview.callHandler("JSCLoadingState", "loaded"));');
+      execute(
+          'chatBox.mount(document.getElementById("talkjs-container")).then(() => window.flutter_inappwebview.callHandler("JSCLoadingState", "loaded"));');
     } else {
       // If it's not the first time that the widget is built,
       // then check what needs to be rebuilt
@@ -186,7 +194,7 @@ class ChatBoxState extends State<ChatBox> {
       final chatBoxRecreated = _checkRecreateChatBox();
 
       if (chatBoxRecreated) {
-      // messageFilter and highlightedWords are set as options for the chatbox
+        // messageFilter and highlightedWords are set as options for the chatbox
         _createConversation();
       } else {
         _checkActionHandlers();
@@ -210,42 +218,62 @@ class ChatBoxState extends State<ChatBox> {
       ),
       onWebViewCreated: _onWebViewCreated,
       onLoadStop: _onLoadStop,
-      onConsoleMessage: (InAppWebViewController controller, ConsoleMessage message) {
+      onConsoleMessage:
+          (InAppWebViewController controller, ConsoleMessage message) {
         print("chatbox [${message.messageLevel}] ${message.message}");
       },
       gestureRecognizers: {
         // We need only the VerticalDragGestureRecognizer in order to be able to scroll through the messages
         Factory(() => VerticalDragGestureRecognizer()),
       },
-      onGeolocationPermissionsShowPrompt: (InAppWebViewController controller, String origin) async {
+      onGeolocationPermissionsShowPrompt:
+          (InAppWebViewController controller, String origin) async {
         print("📘 chatbox onGeolocationPermissionsShowPrompt ($origin)");
 
         final granted = await Permission.location.request().isGranted;
 
-        return GeolocationPermissionShowPromptResponse(origin: origin, allow: granted, retain: true);
+        return GeolocationPermissionShowPromptResponse(
+            origin: origin, allow: granted, retain: true);
       },
-      onPermissionRequest: (InAppWebViewController controller, PermissionRequest permissionRequest) async {
+      onPermissionRequest: (InAppWebViewController controller,
+          PermissionRequest permissionRequest) async {
         print("📘 chatbox onPermissionRequest");
 
         var granted = false;
 
-        if (permissionRequest.resources.indexOf(PermissionResourceType.MICROPHONE) >= 0) {
+        if (permissionRequest.resources
+                .indexOf(PermissionResourceType.MICROPHONE) >=
+            0) {
           granted = await Permission.microphone.request().isGranted;
         }
 
-        return PermissionResponse(resources: permissionRequest.resources, action: granted ? PermissionResponseAction.GRANT : PermissionResponseAction.DENY);
+        return PermissionResponse(
+            resources: permissionRequest.resources,
+            action: granted
+                ? PermissionResponseAction.GRANT
+                : PermissionResponseAction.DENY);
       },
-      shouldOverrideUrlLoading: (InAppWebViewController controller, NavigationAction navigationAction) async {
-        if (navigationAction.navigationType == NavigationType.LINK_ACTIVATED) {
-          if (await launchUrl(navigationAction.request.url!)) {
-            // We launched the browser, so we don't navigate to the URL in the WebView
-            return NavigationActionPolicy.CANCEL;
-          } else {
-            // We couldn't launch the external browser, so as a fallback we're using the default action
-            return NavigationActionPolicy.ALLOW;
+      shouldOverrideUrlLoading: (
+        InAppWebViewController controller,
+        NavigationAction navigationAction,
+      ) async {
+        var overridden = widget.overrideUrlLoading == null
+            ? false
+            : await widget.overrideUrlLoading!(navigationAction.request.url!);
+        if (!overridden) {
+          if (navigationAction.navigationType ==
+              NavigationType.LINK_ACTIVATED) {
+            if (await launchUrl(navigationAction.request.url!)) {
+              // We launched the browser, so we don't navigate to the URL in the WebView
+              return NavigationActionPolicy.CANCEL;
+            } else {
+              // We couldn't launch the external browser, so as a fallback we're using the default action
+              return NavigationActionPolicy.ALLOW;
+            }
           }
+          return NavigationActionPolicy.ALLOW;
         }
-        return NavigationActionPolicy.ALLOW;
+        return NavigationActionPolicy.CANCEL;
       },
     );
   }
@@ -263,15 +291,19 @@ class ChatBoxState extends State<ChatBox> {
     _oldHighlightedWords = List<String>.of(widget.highlightedWords);
     _oldMessageFilter = MessagePredicate.of(widget.messageFilter);
 
-    execute('chatBox = session.createChatbox(${_oldOptions!.getJsonString(this)});');
+    execute(
+        'chatBox = session.createChatbox(${_oldOptions!.getJsonString(this)});');
 
-    execute('chatBox.onSendMessage((event) => window.flutter_inappwebview.callHandler("JSCSendMessage", JSON.stringify(event)));');
-    execute('chatBox.onTranslationToggled((event) => window.flutter_inappwebview.callHandler("JSCTranslationToggled", JSON.stringify(event)));');
+    execute(
+        'chatBox.onSendMessage((event) => window.flutter_inappwebview.callHandler("JSCSendMessage", JSON.stringify(event)));');
+    execute(
+        'chatBox.onTranslationToggled((event) => window.flutter_inappwebview.callHandler("JSCTranslationToggled", JSON.stringify(event)));');
 
     if (widget.onCustomMessageAction != null) {
       _oldCustomActions = Set<String>.of(widget.onCustomMessageAction!.keys);
       for (var action in _oldCustomActions) {
-        execute('chatBox.onCustomMessageAction("$action", customMessageActionHandler);');
+        execute(
+            'chatBox.onCustomMessageAction("$action", customMessageActionHandler);');
       }
     } else {
       _oldCustomActions = {};
@@ -318,7 +350,8 @@ class ChatBoxState extends State<ChatBox> {
         if (!_oldCustomActions.contains(action)) {
           _oldCustomActions.add(action);
 
-          execute('chatBox.onCustomMessageAction("$action", customMessageActionHandler);');
+          execute(
+              'chatBox.onCustomMessageAction("$action", customMessageActionHandler);');
 
           retval = true;
         }
@@ -331,27 +364,29 @@ class ChatBoxState extends State<ChatBox> {
   }
 
   void _createConversation() {
-      final result = <String, dynamic>{};
+    final result = <String, dynamic>{};
 
-      _oldAsGuest = widget.asGuest;
-      if (_oldAsGuest != null) {
-        result['asGuest'] = _oldAsGuest;
-      }
+    _oldAsGuest = widget.asGuest;
+    if (_oldAsGuest != null) {
+      result['asGuest'] = _oldAsGuest;
+    }
 
-      _oldConversation = widget.conversation;
-      if (_oldConversation != null) {
-        execute('chatBox.select(${getConversationVariableName(_oldConversation!)}, ${json.encode(result)});');
+    _oldConversation = widget.conversation;
+    if (_oldConversation != null) {
+      execute(
+          'chatBox.select(${getConversationVariableName(_oldConversation!)}, ${json.encode(result)});');
+    } else {
+      if (result.isNotEmpty) {
+        execute('chatBox.select(undefined, ${json.encode(result)});');
       } else {
-        if (result.isNotEmpty) {
-          execute('chatBox.select(undefined, ${json.encode(result)});');
-        } else {
-          execute('chatBox.select(undefined);');
-        }
+        execute('chatBox.select(undefined);');
       }
+    }
   }
 
   bool _checkRecreateConversation() {
-    if ((widget.asGuest != _oldAsGuest) || (widget.conversation != _oldConversation)) {
+    if ((widget.asGuest != _oldAsGuest) ||
+        (widget.conversation != _oldConversation)) {
       _createConversation();
 
       return true;
@@ -361,9 +396,10 @@ class ChatBoxState extends State<ChatBox> {
   }
 
   void _setHighlightedWords() {
-      _oldHighlightedWords = List<String>.of(widget.highlightedWords);
+    _oldHighlightedWords = List<String>.of(widget.highlightedWords);
 
-      execute('chatBox.setHighlightedWords(${json.encode(_oldHighlightedWords)});');
+    execute(
+        'chatBox.setHighlightedWords(${json.encode(_oldHighlightedWords)});');
   }
 
   bool _checkHighlightedWords() {
@@ -377,9 +413,9 @@ class ChatBoxState extends State<ChatBox> {
   }
 
   void _setMessageFilter() {
-      _oldMessageFilter = MessagePredicate.of(widget.messageFilter);
+    _oldMessageFilter = MessagePredicate.of(widget.messageFilter);
 
-      execute('chatBox.setMessageFilter(${json.encode(_oldMessageFilter)});');
+    execute('chatBox.setMessageFilter(${json.encode(_oldMessageFilter)});');
   }
 
   bool _checkMessageFilter() {
@@ -397,13 +433,20 @@ class ChatBoxState extends State<ChatBox> {
       print('📗 chatbox._onWebViewCreated');
     }
 
-    controller.addJavaScriptHandler(handlerName: 'JSCSendMessage', callback: _jscSendMessage);
-    controller.addJavaScriptHandler(handlerName: 'JSCTranslationToggled', callback: _jscTranslationToggled);
-    controller.addJavaScriptHandler(handlerName: 'JSCLoadingState', callback: _jscLoadingState);
-    controller.addJavaScriptHandler(handlerName: 'JSCCustomMessageAction', callback: _jscCustomMessageAction);
+    controller.addJavaScriptHandler(
+        handlerName: 'JSCSendMessage', callback: _jscSendMessage);
+    controller.addJavaScriptHandler(
+        handlerName: 'JSCTranslationToggled', callback: _jscTranslationToggled);
+    controller.addJavaScriptHandler(
+        handlerName: 'JSCLoadingState', callback: _jscLoadingState);
+    controller.addJavaScriptHandler(
+        handlerName: 'JSCCustomMessageAction',
+        callback: _jscCustomMessageAction);
 
-    String htmlData = await rootBundle.loadString('packages/talkjs_flutter/assets/index.html');
-    controller.loadData(data: htmlData, baseUrl: WebUri("https://app.talkjs.com"));
+    String htmlData = await rootBundle
+        .loadString('packages/talkjs_flutter/assets/index.html');
+    controller.loadData(
+        data: htmlData, baseUrl: WebUri("https://app.talkjs.com"));
   }
 
   void _onLoadStop(InAppWebViewController controller, WebUri? url) async {
@@ -451,7 +494,8 @@ class ChatBoxState extends State<ChatBox> {
       print('📗 chatbox._jscTranslationToggled: $message');
     }
 
-    widget.onTranslationToggled?.call(TranslationToggledEvent.fromJson(json.decode(message)));
+    widget.onTranslationToggled
+        ?.call(TranslationToggledEvent.fromJson(json.decode(message)));
   }
 
   void _jscLoadingState(List<dynamic> arguments) {
@@ -474,7 +518,8 @@ class ChatBoxState extends State<ChatBox> {
     Map<String, dynamic> jsonMessage = json.decode(message);
     String action = jsonMessage['action'];
 
-    widget.onCustomMessageAction?[action]?.call(MessageActionEvent.fromJson(jsonMessage));
+    widget.onCustomMessageAction?[action]
+        ?.call(MessageActionEvent.fromJson(jsonMessage));
   }
 
   /// For internal use only. Implementation detail that may change anytime.
@@ -520,7 +565,8 @@ class ChatBoxState extends State<ChatBox> {
 
       _conversations[conversation.id] = variableName;
 
-      execute('let $variableName = session.getOrCreateConversation("${conversation.id}")');
+      execute(
+          'let $variableName = session.getOrCreateConversation("${conversation.id}")');
 
       _setConversationAttributes(variableName, conversation);
       _setConversationParticipants(variableName, conversation);
@@ -531,7 +577,8 @@ class ChatBoxState extends State<ChatBox> {
 
       _setConversationAttributes(variableName, conversation);
 
-      if (!setEquals(conversation.participants, _conversationObjs[conversation.id]!.participants)) {
+      if (!setEquals(conversation.participants,
+          _conversationObjs[conversation.id]!.participants)) {
         _setConversationParticipants(variableName, conversation);
       }
 
@@ -541,7 +588,8 @@ class ChatBoxState extends State<ChatBox> {
     return _conversations[conversation.id]!;
   }
 
-  void _setConversationAttributes(String variableName, Conversation conversation) {
+  void _setConversationAttributes(
+      String variableName, Conversation conversation) {
     final attributes = <String, dynamic>{};
 
     if (conversation.custom != null) {
@@ -565,7 +613,8 @@ class ChatBoxState extends State<ChatBox> {
     }
   }
 
-  void _setConversationParticipants(String variableName, Conversation conversation) {
+  void _setConversationParticipants(
+      String variableName, Conversation conversation) {
     for (var participant in conversation.participants) {
       final userVariableName = getUserVariableName(participant.user);
       final result = <String, dynamic>{};
@@ -578,7 +627,8 @@ class ChatBoxState extends State<ChatBox> {
         result['notify'] = participant.notify!.getValue();
       }
 
-      execute('$variableName.setParticipant($userVariableName, ${json.encode(result)});');
+      execute(
+          '$variableName.setParticipant($userVariableName, ${json.encode(result)});');
     }
   }
 
@@ -612,4 +662,3 @@ class ChatBoxState extends State<ChatBox> {
     }
   }
 }
-


### PR DESCRIPTION
Sometimes, open the url in a browser is not the best option. For example: an OGG audio file has no player support in iOS browsers, so we could open a flutter dialog to play the file correctly (using a VLC player or other third party plugin).
With the `overrideUrlLoading` param, we can add custom behavior to urls without affecting the natural flow.

The updates were basically in 3 places:
```dart
final Future<bool> Function(Uri uri)? overrideUrlLoading; // line 86 - the new optional widget param

// ...

this.overrideUrlLoading, // line 107 - the new optional widget param in constructor

// ...

// lines 260 to 276
var overridden = widget.overrideUrlLoading == null
            ? false
            : await widget.overrideUrlLoading!(navigationAction.request.url!);
        if (!overridden) {
          if (navigationAction.navigationType ==
              NavigationType.LINK_ACTIVATED) {
            if (await launchUrl(navigationAction.request.url!)) {
              // We launched the browser, so we don't navigate to the URL in the WebView
              return NavigationActionPolicy.CANCEL;
            } else {
              // We couldn't launch the external browser, so as a fallback we're using the default action
              return NavigationActionPolicy.ALLOW;
            }
          }
          return NavigationActionPolicy.ALLOW;
        }
        return NavigationActionPolicy.CANCEL;
```

All the other updates was just the VS Code `formatOnSave` editor setting in action.