### PR TITLE
Re-enabled the onUrlNavigation callback on the ChatBox

### DIFF
--- a/lib/src/chatbox.dart
+++ b/lib/src/chatbox.dart
@@ -89,6 +89,7 @@ class ChatBox extends StatefulWidget {
   final TranslationToggledHandler? onTranslationToggled;
   final LoadingStateHandler? onLoadingStateChanged;
   final Map<String, MessageActionHandler>? onCustomMessageAction;
+  final NavigationHandler? onUrlNavigation;
 
   const ChatBox({
     Key? key,
@@ -107,6 +108,7 @@ class ChatBox extends StatefulWidget {
     this.onTranslationToggled,
     this.onLoadingStateChanged,
     this.onCustomMessageAction,
+    this.onUrlNavigation,
   }) : super(key: key);
 
   @override
@@ -237,15 +239,27 @@ class ChatBoxState extends State<ChatBox> {
       },
       shouldOverrideUrlLoading: (InAppWebViewController controller, NavigationAction navigationAction) async {
         if (navigationAction.navigationType == NavigationType.LINK_ACTIVATED) {
-          if (await launchUrl(navigationAction.request.url!)) {
-            // We launched the browser, so we don't navigate to the URL in the WebView
-            return NavigationActionPolicy.CANCEL;
-          } else {
-            // We couldn't launch the external browser, so as a fallback we're using the default action
-            return NavigationActionPolicy.ALLOW;
+          var shouldOpenBrowser = true;
+
+          if (widget.onUrlNavigation != null) {
+            // The onUrlNavigation function has been defined, so let's see if we should open the browser or not
+            if (widget.onUrlNavigation!(UrlNavigationRequest(navigationAction.request.url!.rawValue)) == UrlNavigationAction.deny) {
+              shouldOpenBrowser = false;
+            }
+          }
+
+          if (shouldOpenBrowser) {
+            if (await launchUrl(navigationAction.request.url!)) {
+              // We launched the browser, so we don't navigate to the URL in the WebView
+              return NavigationActionPolicy.CANCEL;
+            } else {
+              // We couldn't launch the external browser, so as a fallback we're using the default action
+              return NavigationActionPolicy.ALLOW;
+            }
           }
         }
-        return NavigationActionPolicy.ALLOW;
+
+        return NavigationActionPolicy.CANCEL;
       },
     );
   }

--- a/lib/src/chatbox.dart
+++ b/lib/src/chatbox.dart
@@ -239,27 +239,23 @@ class ChatBoxState extends State<ChatBox> {
       },
       shouldOverrideUrlLoading: (InAppWebViewController controller, NavigationAction navigationAction) async {
         if (navigationAction.navigationType == NavigationType.LINK_ACTIVATED) {
-          var shouldOpenBrowser = true;
-
           if (widget.onUrlNavigation != null) {
             // The onUrlNavigation function has been defined, so let's see if we should open the browser or not
             if (widget.onUrlNavigation!(UrlNavigationRequest(navigationAction.request.url!.rawValue)) == UrlNavigationAction.deny) {
-              shouldOpenBrowser = false;
+              return NavigationActionPolicy.CANCEL;
             }
           }
 
-          if (shouldOpenBrowser) {
-            if (await launchUrl(navigationAction.request.url!)) {
-              // We launched the browser, so we don't navigate to the URL in the WebView
-              return NavigationActionPolicy.CANCEL;
-            } else {
-              // We couldn't launch the external browser, so as a fallback we're using the default action
-              return NavigationActionPolicy.ALLOW;
-            }
+          if (await launchUrl(navigationAction.request.url!)) {
+            // We launched the browser, so we don't navigate to the URL in the WebView
+            return NavigationActionPolicy.CANCEL;
+          } else {
+            // We couldn't launch the external browser, so as a fallback we're using the default action
+            return NavigationActionPolicy.ALLOW;
           }
         }
 
-        return NavigationActionPolicy.CANCEL;
+        return NavigationActionPolicy.ALLOW;
       },
     );
   }


### PR DESCRIPTION
This re-enables the `onUlrNavigation` callback for the ChatBox, with the exact same API as #15 (I found out that there is at least 1 more customer that maintains his own fork of our Flutter SDK that re-enabled this change, even though it has never been documented).

This should be used instead of #27 only because of previous API compatibility.