### PR TITLE
Fix marking messages as read when loading conversation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.9.1
+
+- Fix messages getting marked as read only after clicking the message field.
+  Now they should get marked after the Chatbox has loaded.
+
 ## 0.9.0
 
 - Add `setPushRegistration`, `unsetPushRegistration`, and `clearPushRegistrations` to the Session.

--- a/example/push_notifications/android/build.gradle
+++ b/example/push_notifications/android/build.gradle
@@ -27,6 +27,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/push_notifications/pubspec.lock
+++ b/example/push_notifications/pubspec.lock
@@ -395,7 +395,7 @@ packages:
       path: "../.."
       relative: true
     source: path
-    version: "0.8.1"
+    version: "0.9.0"
   talkjs_flutter_inappwebview:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talkjs_flutter
 description: Official TalkJS SDK for Flutter
-version: 0.9.0
+version: 0.9.1
 homepage: https://talkjs.com
 
 environment:


### PR DESCRIPTION
This fixes the bug where a user needed to click the MessageField in order for the UI to be recognized as in focus and subsequently have its messages marked as read.