### PR TITLE
(Chatbox): Fix user activated link navigation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.3
+
+- Fix links in Android not opening in the external browser by default.
+
 ## 0.9.2
 
 - Fix build issue on Xcode 15.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talkjs_flutter
 description: Official TalkJS SDK for Flutter
-version: 0.9.2
+version: 0.9.3
 homepage: https://talkjs.com
 
 environment:


### PR DESCRIPTION
When the user clicks on a link, the default behaviour should be that the link in question is opened in the external browser.  Due to an [implementation detail](https://developer.android.com/develop/ui/views/layout/webapps/webview#HandlingNavigation) in the inappwebview package, this wasn't the case.

Specifying the launch mode in `launchUrl` was necessary as without it, the link would still open in the webview.