### PR TITLE
Added Compound predicates

### DIFF
--- a/lib/src/chatbox.dart
+++ b/lib/src/chatbox.dart
@@ -94,7 +94,7 @@ class ChatBox extends StatefulWidget {
   final String? theme;
   final ThemeOptions? themeOptions;
   final TranslateConversations? translateConversations;
-  final List<String> highlightedWords = const <String>[];
+  final List<String> highlightedWords;
   final BaseMessagePredicate? messageFilter;
 
   final Conversation? conversation;
@@ -117,7 +117,7 @@ class ChatBox extends StatefulWidget {
     this.theme,
     this.themeOptions,
     this.translateConversations,
-    //this.highlightedWords = const <String>[], // Commented out due to bug #1953
+    this.highlightedWords = const <String>[],
     this.messageFilter,
     this.conversation,
     this.asGuest,
@@ -337,11 +337,10 @@ class ChatBoxState extends State<ChatBox> {
       translateConversations: widget.translateConversations,
     );
 
-    _oldHighlightedWords = List<String>.of(widget.highlightedWords);
-    _oldMessageFilter = widget.messageFilter?.clone();
+    execute('chatBox = session.createChatbox(${_oldOptions});');
 
-    execute(
-        'chatBox = session.createChatbox(${_oldOptions!.getJsonString(this)});');
+    _setMessageFilter();
+    _setHighlightedWords();
 
     execute(
         'chatBox.onSendMessage((event) => window.flutter_inappwebview.callHandler("JSCSendMessage", JSON.stringify(event)));');
@@ -742,19 +741,6 @@ class ChatBoxState extends State<ChatBox> {
 
       execute(
           '$variableName.setParticipant($userVariableName, ${json.encode(result)});');
-    }
-  }
-
-  /// For internal use only. Implementation detail that may change anytime.
-  ///
-  /// Sets the options for ChatBoxOptions for the properties where there exists
-  /// both a declarative option and an imperative method
-  void setExtraOptions(Map<String, dynamic> result) {
-    result['highlightedWords'] = widget.highlightedWords;
-    if (widget.messageFilter != null) {
-      result['messageFilter'] = widget.messageFilter;
-    } else {
-      result['messageFilter'] = new Map<String, dynamic>();
     }
   }
 

--- a/lib/src/chatoptions.dart
+++ b/lib/src/chatoptions.dart
@@ -186,14 +186,8 @@ class ChatBoxOptions {
     this.translateConversations,
   });
 
-  /// For internal use only. Implementation detail that may change anytime.
-  ///
-  /// This method is used instead of toJson, as we need to output valid JS
-  /// that is not valid JSON.
-  /// The toJson method is intentionally omitted, to produce an error if
-  /// someone tries to convert this object to JSON instead of using the
-  /// getJsonString method.
-  String getJsonString(ChatBoxState chatBox) {
+  @override
+  String toString() {
     final result = <String, dynamic>{};
 
     if (dir != null) {
@@ -222,8 +216,6 @@ class ChatBoxOptions {
     if (translateConversations != null) {
       result['translateConversations'] = translateConversations!.getValue();
     }
-
-    chatBox.setExtraOptions(result);
 
     return json.encode(result);
   }

--- a/lib/src/conversationlist.dart
+++ b/lib/src/conversationlist.dart
@@ -94,7 +94,7 @@ class ConversationList extends StatefulWidget {
   final String? theme;
   final ThemeOptions? themeOptions;
 
-  final ConversationPredicate feedFilter;
+  final BaseConversationPredicate? feedFilter;
 
   final SelectConversationHandler? onSelectConversation;
   final LoadingStateHandler? onLoadingStateChanged;
@@ -105,7 +105,7 @@ class ConversationList extends StatefulWidget {
     this.showFeedHeader,
     this.theme,
     this.themeOptions,
-    this.feedFilter = const ConversationPredicate(),
+    this.feedFilter,
     this.onSelectConversation,
     this.onLoadingStateChanged,
   }) : super(key: key);
@@ -130,7 +130,7 @@ class ConversationListState extends State<ConversationList> {
   final _users = <String, String>{};
 
   /// Objects stored for comparing changes
-  ConversationPredicate _oldFeedFilter = const ConversationPredicate();
+  BaseConversationPredicate? _oldFeedFilter;
 
   @override
   Widget build(BuildContext context) {
@@ -192,7 +192,7 @@ class ConversationListState extends State<ConversationList> {
       themeOptions: widget.themeOptions,
     );
 
-    _oldFeedFilter = ConversationPredicate.of(widget.feedFilter);
+    _oldFeedFilter = widget.feedFilter?.clone();
 
     execute(
         'const conversationList = session.createInbox(${options.getJsonString(this)});');
@@ -204,9 +204,14 @@ class ConversationListState extends State<ConversationList> {
   }
 
   void _setFeedFilter() {
-    _oldFeedFilter = ConversationPredicate.of(widget.feedFilter);
+    _oldFeedFilter = widget.feedFilter?.clone();
 
-    execute('conversationList.setFeedFilter(${json.encode(_oldFeedFilter)});');
+    if (_oldFeedFilter != null) {
+      execute(
+          'conversationList.setFeedFilter(${json.encode(_oldFeedFilter)});');
+    } else {
+      execute('conversationList.setFeedFilter({});');
+    }
   }
 
   bool _checkFeedFilter() {
@@ -316,7 +321,11 @@ class ConversationListState extends State<ConversationList> {
   /// Sets the options for ConversationListOptions for the properties where there exists
   /// both a declarative option and an imperative method
   void setExtraOptions(Map<String, dynamic> result) {
-    result['feedFilter'] = widget.feedFilter;
+    if (widget.feedFilter != null) {
+      result['feedFilter'] = widget.feedFilter;
+    } else {
+      result['feedFilter'] = new Map<String, dynamic>();
+    }
   }
 
   /// For internal use only. Implementation detail that may change anytime.

--- a/lib/src/conversationlist.dart
+++ b/lib/src/conversationlist.dart
@@ -61,13 +61,8 @@ class ConversationListOptions {
     this.themeOptions,
   });
 
-  /// For internal use only. Implementation detail that may change anytime.
-  ///
-  /// This method is used instead of toJson for coherence with ChatBoxOptions.
-  /// The toJson method is intentionally omitted, to produce an error if
-  /// someone tries to convert this object to JSON instead of using the
-  /// getJsonString method.
-  String getJsonString(ConversationListState conversationList) {
+  @override
+  String toString() {
     final result = <String, dynamic>{};
 
     if (showFeedHeader != null) {
@@ -79,8 +74,6 @@ class ConversationListOptions {
     } else if (theme != null) {
       result['theme'] = theme;
     }
-
-    conversationList.setExtraOptions(result);
 
     return json.encode(result);
   }
@@ -192,10 +185,9 @@ class ConversationListState extends State<ConversationList> {
       themeOptions: widget.themeOptions,
     );
 
-    _oldFeedFilter = widget.feedFilter?.clone();
+    execute('const conversationList = session.createInbox(${options});');
 
-    execute(
-        'const conversationList = session.createInbox(${options.getJsonString(this)});');
+    _setFeedFilter();
 
     execute('''conversationList.onSelectConversation((event) => {
       event.preventDefault();
@@ -314,18 +306,6 @@ class ConversationListState extends State<ConversationList> {
     }
 
     return _users[user.id]!;
-  }
-
-  /// For internal use only. Implementation detail that may change anytime.
-  ///
-  /// Sets the options for ConversationListOptions for the properties where there exists
-  /// both a declarative option and an imperative method
-  void setExtraOptions(Map<String, dynamic> result) {
-    if (widget.feedFilter != null) {
-      result['feedFilter'] = widget.feedFilter;
-    } else {
-      result['feedFilter'] = new Map<String, dynamic>();
-    }
   }
 
   /// For internal use only. Implementation detail that may change anytime.

--- a/lib/src/predicate.dart
+++ b/lib/src/predicate.dart
@@ -255,7 +255,16 @@ class ConversationAccessLevel {
   String toString() => _value;
 }
 
-class ConversationPredicate {
+abstract class BaseConversationPredicate {
+  const BaseConversationPredicate();
+  String toString();
+  dynamic toJson();
+  BaseConversationPredicate clone();
+  bool operator ==(Object other);
+  int get hashCode;
+}
+
+class ConversationPredicate extends BaseConversationPredicate {
   /// Only select conversations that the current user as specific access to.
   final FieldPredicate<ConversationAccessLevel>? access;
 
@@ -294,11 +303,17 @@ class ConversationPredicate {
             : null);
 
   @override
+  BaseConversationPredicate clone() {
+    return ConversationPredicate.of(this);
+  }
+
+  @override
   String toString() {
     return json.encode(this);
   }
 
-  Map<String, dynamic> toJson() {
+  @override
+  dynamic toJson() {
     final result = <String, dynamic>{};
 
     if (access != null) {
@@ -324,6 +339,7 @@ class ConversationPredicate {
     return result;
   }
 
+  @override
   bool operator ==(Object other) {
     if (identical(this, other)) {
       return true;
@@ -356,6 +372,7 @@ class ConversationPredicate {
     return true;
   }
 
+  @override
   int get hashCode => Object.hash(
         access,
         (custom != null ? Object.hashAll(custom!.keys) : custom),
@@ -364,6 +381,64 @@ class ConversationPredicate {
         lastMessageTs,
         subject,
       );
+}
+
+class CompoundConversationPredicate extends BaseConversationPredicate {
+  final String _operand;
+  List<ConversationPredicate> _values;
+
+  CompoundConversationPredicate.any(List<ConversationPredicate> predicates)
+      : _operand = 'any',
+        _values = predicates;
+
+  CompoundConversationPredicate.of(CompoundConversationPredicate other)
+      : _operand = other._operand,
+        _values = List<ConversationPredicate>.of(other._values);
+
+  @override
+  BaseConversationPredicate clone() {
+    return CompoundConversationPredicate.of(this);
+  }
+
+  @override
+  String toString() {
+    return json.encode(this);
+  }
+
+  @override
+  dynamic toJson() {
+    final result = <dynamic>[];
+
+    result.add(_operand);
+
+    result.add(_values);
+
+    return result;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    if (!(other is CompoundConversationPredicate)) {
+      return false;
+    }
+
+    if (_operand != other._operand) {
+      return false;
+    }
+
+    if (!listEquals(_values, other._values)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(_operand, Object.hashAll(_values));
 }
 
 class MessageOrigin {
@@ -476,7 +551,16 @@ class SenderPredicate {
       );
 }
 
-class MessagePredicate {
+abstract class BaseMessagePredicate {
+  const BaseMessagePredicate();
+  String toString();
+  dynamic toJson();
+  BaseMessagePredicate clone();
+  bool operator ==(Object other);
+  int get hashCode;
+}
+
+class MessagePredicate extends BaseMessagePredicate {
   /// Only select messages that have particular custom fields set to particular values.
   final Map<String, CustomFieldPredicate>? custom;
 
@@ -506,11 +590,17 @@ class MessagePredicate {
             : null);
 
   @override
+  BaseMessagePredicate clone() {
+    return MessagePredicate.of(this);
+  }
+
+  @override
   String toString() {
     return json.encode(this);
   }
 
-  Map<String, dynamic> toJson() {
+  @override
+  dynamic toJson() {
     final result = <String, dynamic>{};
 
     if (custom != null) {
@@ -532,6 +622,7 @@ class MessagePredicate {
     return result;
   }
 
+  @override
   bool operator ==(Object other) {
     if (identical(this, other)) {
       return true;
@@ -560,6 +651,7 @@ class MessagePredicate {
     return true;
   }
 
+  @override
   int get hashCode => Object.hash(
         (custom != null ? Object.hashAll(custom!.keys) : custom),
         (custom != null ? Object.hashAll(custom!.values) : custom),
@@ -567,4 +659,62 @@ class MessagePredicate {
         sender,
         type,
       );
+}
+
+class CompoundMessagePredicate extends BaseMessagePredicate {
+  final String _operand;
+  List<MessagePredicate> _values;
+
+  CompoundMessagePredicate.any(List<MessagePredicate> predicates)
+      : _operand = 'any',
+        _values = predicates;
+
+  CompoundMessagePredicate.of(CompoundMessagePredicate other)
+      : _operand = other._operand,
+        _values = List<MessagePredicate>.of(other._values);
+
+  @override
+  BaseMessagePredicate clone() {
+    return CompoundMessagePredicate.of(this);
+  }
+
+  @override
+  String toString() {
+    return json.encode(this);
+  }
+
+  @override
+  dynamic toJson() {
+    final result = <dynamic>[];
+
+    result.add(_operand);
+
+    result.add(_values);
+
+    return result;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    if (!(other is CompoundMessagePredicate)) {
+      return false;
+    }
+
+    if (_operand != other._operand) {
+      return false;
+    }
+
+    if (!listEquals(_values, other._values)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hash(_operand, Object.hashAll(_values));
 }

--- a/test/talkjs_test.dart
+++ b/test/talkjs_test.dart
@@ -11,255 +11,355 @@ void main() {
   });
 
   test('test FieldPredicate ==', () {
-    expect(FieldPredicate<ConversationAccessLevel>.equals(ConversationAccessLevel.readWrite) == FieldPredicate<ConversationAccessLevel>.equals(ConversationAccessLevel.readWrite), true);
-    expect(FieldPredicate<String>.notOneOf(['it', 'fr']) == FieldPredicate<String>.notOneOf(['it', 'fr']), true);
+    expect(
+        FieldPredicate<ConversationAccessLevel>.equals(
+                ConversationAccessLevel.readWrite) ==
+            FieldPredicate<ConversationAccessLevel>.equals(
+                ConversationAccessLevel.readWrite),
+        true);
+    expect(
+        FieldPredicate<String>.notOneOf(['it', 'fr']) ==
+            FieldPredicate<String>.notOneOf(['it', 'fr']),
+        true);
   });
 
   test('test CustomFieldPredicate ==', () {
-    expect(CustomFieldPredicate.exists() == CustomFieldPredicate.exists(), true);
-    expect(CustomFieldPredicate.equals('it') == CustomFieldPredicate.equals('it'), true);
-    expect(CustomFieldPredicate.oneOf(['it', 'fr']) == CustomFieldPredicate.oneOf(['it', 'fr']), true);
+    expect(
+        CustomFieldPredicate.exists() == CustomFieldPredicate.exists(), true);
+    expect(
+        CustomFieldPredicate.equals('it') == CustomFieldPredicate.equals('it'),
+        true);
+    expect(
+        CustomFieldPredicate.oneOf(['it', 'fr']) ==
+            CustomFieldPredicate.oneOf(['it', 'fr']),
+        true);
   });
 
   test('test ConversationPredicate ==', () {
     expect(
-      ConversationPredicate(
-        access: FieldPredicate.notEquals(ConversationAccessLevel.none),
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        hasUnreadMessages: false,
-        lastMessageTs: NumberPredicate.greaterThan(1679298371586),
-        subject: FieldPredicate.equals(null),
-      ) == ConversationPredicate(
-        access: FieldPredicate.notEquals(ConversationAccessLevel.none),
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        hasUnreadMessages: false,
-        lastMessageTs: NumberPredicate.greaterThan(1679298371586),
-        subject: FieldPredicate.equals(null),
-      )
-    , true);
+        ConversationPredicate(
+              access: FieldPredicate.notEquals(ConversationAccessLevel.none),
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              hasUnreadMessages: false,
+              lastMessageTs: NumberPredicate.greaterThan(1679298371586),
+              subject: FieldPredicate.equals(null),
+            ) ==
+            ConversationPredicate(
+              access: FieldPredicate.notEquals(ConversationAccessLevel.none),
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              hasUnreadMessages: false,
+              lastMessageTs: NumberPredicate.greaterThan(1679298371586),
+              subject: FieldPredicate.equals(null),
+            ),
+        true);
   });
 
   test('test SenderPredicate ==', () {
     expect(
-      SenderPredicate(
-        id: FieldPredicate.notEquals('INVALID_ID'),
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        locale: FieldPredicate.notOneOf(['it', 'fr']),
-        role: FieldPredicate.notEquals('admin'),
-      ) == SenderPredicate(
-        id: FieldPredicate.notEquals('INVALID_ID'),
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        locale: FieldPredicate.notOneOf(['it', 'fr']),
-        role: FieldPredicate.notEquals('admin'),
-      )
-    , true);
+        SenderPredicate(
+              id: FieldPredicate.notEquals('INVALID_ID'),
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              locale: FieldPredicate.notOneOf(['it', 'fr']),
+              role: FieldPredicate.notEquals('admin'),
+            ) ==
+            SenderPredicate(
+              id: FieldPredicate.notEquals('INVALID_ID'),
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              locale: FieldPredicate.notOneOf(['it', 'fr']),
+              role: FieldPredicate.notEquals('admin'),
+            ),
+        true);
   });
 
   test('test MessagePredicate ==', () {
     expect(
-      MessagePredicate(
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        origin: FieldPredicate.equals(MessageOrigin.web),
-        sender: SenderPredicate(
-          id: FieldPredicate.notEquals('INVALID_ID'),
-          custom: {
-            'seller': CustomFieldPredicate.exists(),
-            'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-            'visibility': CustomFieldPredicate.equals('visible'),
-          },
-          locale: FieldPredicate.notOneOf(['it', 'fr']),
-          role: FieldPredicate.notEquals('admin'),
-        ),
-        type: FieldPredicate.notEquals(MessageType.systemMessage),
-      ) == MessagePredicate(
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        origin: FieldPredicate.equals(MessageOrigin.web),
-        sender: SenderPredicate(
-          id: FieldPredicate.notEquals('INVALID_ID'),
-          custom: {
-            'seller': CustomFieldPredicate.exists(),
-            'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-            'visibility': CustomFieldPredicate.equals('visible'),
-          },
-          locale: FieldPredicate.notOneOf(['it', 'fr']),
-          role: FieldPredicate.notEquals('admin'),
-        ),
-        type: FieldPredicate.notEquals(MessageType.systemMessage),
-      )
-    , true);
+        MessagePredicate(
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              origin: FieldPredicate.equals(MessageOrigin.web),
+              sender: SenderPredicate(
+                id: FieldPredicate.notEquals('INVALID_ID'),
+                custom: {
+                  'seller': CustomFieldPredicate.exists(),
+                  'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                  'visibility': CustomFieldPredicate.equals('visible'),
+                },
+                locale: FieldPredicate.notOneOf(['it', 'fr']),
+                role: FieldPredicate.notEquals('admin'),
+              ),
+              type: FieldPredicate.notEquals(MessageType.systemMessage),
+            ) ==
+            MessagePredicate(
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              origin: FieldPredicate.equals(MessageOrigin.web),
+              sender: SenderPredicate(
+                id: FieldPredicate.notEquals('INVALID_ID'),
+                custom: {
+                  'seller': CustomFieldPredicate.exists(),
+                  'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                  'visibility': CustomFieldPredicate.equals('visible'),
+                },
+                locale: FieldPredicate.notOneOf(['it', 'fr']),
+                role: FieldPredicate.notEquals('admin'),
+              ),
+              type: FieldPredicate.notEquals(MessageType.systemMessage),
+            ),
+        true);
   });
 
   test('test FieldPredicate.of', () {
-    expect(FieldPredicate<ConversationAccessLevel>.of(FieldPredicate<ConversationAccessLevel>.equals(ConversationAccessLevel.readWrite)) == FieldPredicate<ConversationAccessLevel>.equals(ConversationAccessLevel.readWrite), true);
-    expect(FieldPredicate<String>.of(FieldPredicate<String>.notOneOf(['it', 'fr'])) == FieldPredicate<String>.notOneOf(['it', 'fr']), true);
+    expect(
+        FieldPredicate<ConversationAccessLevel>.of(
+                FieldPredicate<ConversationAccessLevel>.equals(
+                    ConversationAccessLevel.readWrite)) ==
+            FieldPredicate<ConversationAccessLevel>.equals(
+                ConversationAccessLevel.readWrite),
+        true);
+    expect(
+        FieldPredicate<String>.of(
+                FieldPredicate<String>.notOneOf(['it', 'fr'])) ==
+            FieldPredicate<String>.notOneOf(['it', 'fr']),
+        true);
   });
 
   test('test CustomFieldPredicate of', () {
-    expect(CustomFieldPredicate.of(CustomFieldPredicate.exists()) == CustomFieldPredicate.exists(), true);
-    expect(CustomFieldPredicate.of(CustomFieldPredicate.equals('it')) == CustomFieldPredicate.equals('it'), true);
-    expect(CustomFieldPredicate.of(CustomFieldPredicate.oneOf(['it', 'fr'])) == CustomFieldPredicate.oneOf(['it', 'fr']), true);
+    expect(
+        CustomFieldPredicate.of(CustomFieldPredicate.exists()) ==
+            CustomFieldPredicate.exists(),
+        true);
+    expect(
+        CustomFieldPredicate.of(CustomFieldPredicate.equals('it')) ==
+            CustomFieldPredicate.equals('it'),
+        true);
+    expect(
+        CustomFieldPredicate.of(CustomFieldPredicate.oneOf(['it', 'fr'])) ==
+            CustomFieldPredicate.oneOf(['it', 'fr']),
+        true);
   });
 
   test('test NumberPredicate.of', () {
-    expect(NumberPredicate.of(NumberPredicate.notBetween([100, 300])) == NumberPredicate.notBetween([100, 300]), true);
+    expect(
+        NumberPredicate.of(NumberPredicate.notBetween([100, 300])) ==
+            NumberPredicate.notBetween([100, 300]),
+        true);
   });
 
   test('test ConversationPredicate of', () {
     expect(
-      ConversationPredicate.of(ConversationPredicate(
-        access: FieldPredicate.notEquals(ConversationAccessLevel.none),
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        hasUnreadMessages: false,
-        lastMessageTs: NumberPredicate.greaterThan(1679298371586),
-        subject: FieldPredicate.notEquals('Pink shoes'),
-      )) == ConversationPredicate(
-        access: FieldPredicate.notEquals(ConversationAccessLevel.none),
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        hasUnreadMessages: false,
-        lastMessageTs: NumberPredicate.greaterThan(1679298371586),
-        subject: FieldPredicate.notEquals('Pink shoes'),
-      )
-    , true);
+        ConversationPredicate.of(ConversationPredicate(
+              access: FieldPredicate.notEquals(ConversationAccessLevel.none),
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              hasUnreadMessages: false,
+              lastMessageTs: NumberPredicate.greaterThan(1679298371586),
+              subject: FieldPredicate.notEquals('Pink shoes'),
+            )) ==
+            ConversationPredicate(
+              access: FieldPredicate.notEquals(ConversationAccessLevel.none),
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              hasUnreadMessages: false,
+              lastMessageTs: NumberPredicate.greaterThan(1679298371586),
+              subject: FieldPredicate.notEquals('Pink shoes'),
+            ),
+        true);
   });
 
   test('test SenderPredicate of', () {
     expect(
-      SenderPredicate.of(SenderPredicate(
-        id: FieldPredicate.notEquals('INVALID_ID'),
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        locale: FieldPredicate.notOneOf(['it', 'fr']),
-        role: FieldPredicate.notEquals('admin'),
-      )) == SenderPredicate(
-        id: FieldPredicate.notEquals('INVALID_ID'),
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        locale: FieldPredicate.notOneOf(['it', 'fr']),
-        role: FieldPredicate.notEquals('admin'),
-      )
-    , true);
+        SenderPredicate.of(SenderPredicate(
+              id: FieldPredicate.notEquals('INVALID_ID'),
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              locale: FieldPredicate.notOneOf(['it', 'fr']),
+              role: FieldPredicate.notEquals('admin'),
+            )) ==
+            SenderPredicate(
+              id: FieldPredicate.notEquals('INVALID_ID'),
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              locale: FieldPredicate.notOneOf(['it', 'fr']),
+              role: FieldPredicate.notEquals('admin'),
+            ),
+        true);
   });
 
   test('test MessagePredicate of', () {
     expect(
-      MessagePredicate.of(MessagePredicate(
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        origin: FieldPredicate.equals(MessageOrigin.web),
-        sender: SenderPredicate(
-          id: FieldPredicate.notEquals('INVALID_ID'),
-          custom: {
-            'seller': CustomFieldPredicate.exists(),
-            'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-            'visibility': CustomFieldPredicate.equals('visible'),
-          },
-          locale: FieldPredicate.notOneOf(['it', 'fr']),
-          role: FieldPredicate.notEquals('admin'),
-        ),
-        type: FieldPredicate.notEquals(MessageType.systemMessage),
-      )) == MessagePredicate(
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        origin: FieldPredicate.equals(MessageOrigin.web),
-        sender: SenderPredicate(
-          id: FieldPredicate.notEquals('INVALID_ID'),
-          custom: {
-            'seller': CustomFieldPredicate.exists(),
-            'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-            'visibility': CustomFieldPredicate.equals('visible'),
-          },
-          locale: FieldPredicate.notOneOf(['it', 'fr']),
-          role: FieldPredicate.notEquals('admin'),
-        ),
-        type: FieldPredicate.notEquals(MessageType.systemMessage),
-      )
-    , true);
+        MessagePredicate.of(MessagePredicate(
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              origin: FieldPredicate.equals(MessageOrigin.web),
+              sender: SenderPredicate(
+                id: FieldPredicate.notEquals('INVALID_ID'),
+                custom: {
+                  'seller': CustomFieldPredicate.exists(),
+                  'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                  'visibility': CustomFieldPredicate.equals('visible'),
+                },
+                locale: FieldPredicate.notOneOf(['it', 'fr']),
+                role: FieldPredicate.notEquals('admin'),
+              ),
+              type: FieldPredicate.notEquals(MessageType.systemMessage),
+            )) ==
+            MessagePredicate(
+              custom: {
+                'seller': CustomFieldPredicate.exists(),
+                'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                'visibility': CustomFieldPredicate.equals('visible'),
+              },
+              origin: FieldPredicate.equals(MessageOrigin.web),
+              sender: SenderPredicate(
+                id: FieldPredicate.notEquals('INVALID_ID'),
+                custom: {
+                  'seller': CustomFieldPredicate.exists(),
+                  'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+                  'visibility': CustomFieldPredicate.equals('visible'),
+                },
+                locale: FieldPredicate.notOneOf(['it', 'fr']),
+                role: FieldPredicate.notEquals('admin'),
+              ),
+              type: FieldPredicate.notEquals(MessageType.systemMessage),
+            ),
+        true);
   });
 
   test('test ConversationPredicate string', () {
     expect(
-      json.encode(ConversationPredicate(
-        access: FieldPredicate.notEquals(ConversationAccessLevel.none),
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        hasUnreadMessages: false,
-        lastMessageTs: NumberPredicate.greaterThan(1679298371586),
-        subject: FieldPredicate.oneOf(['Pink shoes', null]),
-      )),
-      '{"access":["!=","None"],"custom":{"seller":"exists","category":["oneOf",["shoes","sandals"]],"visibility":["==","visible"]},"hasUnreadMessages":false,"lastMessageTs":[">",1679298371586.0],"subject":["oneOf",["Pink shoes",null]]}'
-    );
-  });
-
-  test('test MessagePredicate string', () {
-    expect(
-      json.encode(MessagePredicate(
-        custom: {
-          'seller': CustomFieldPredicate.exists(),
-          'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
-          'visibility': CustomFieldPredicate.equals('visible'),
-        },
-        origin: FieldPredicate.equals(MessageOrigin.web),
-        sender: SenderPredicate(
-          id: FieldPredicate.notEquals('INVALID_ID'),
+        json.encode(ConversationPredicate(
+          access: FieldPredicate.notEquals(ConversationAccessLevel.none),
           custom: {
             'seller': CustomFieldPredicate.exists(),
             'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
             'visibility': CustomFieldPredicate.equals('visible'),
           },
-          locale: FieldPredicate.notOneOf(['it', 'fr']),
-          role: FieldPredicate.notEquals('admin'),
+          hasUnreadMessages: false,
+          lastMessageTs: NumberPredicate.greaterThan(1679298371586),
+          subject: FieldPredicate.oneOf(['Pink shoes', null]),
+        )),
+        '{"access":["!=","None"],"custom":{"seller":"exists","category":["oneOf",["shoes","sandals"]],"visibility":["==","visible"]},"hasUnreadMessages":false,"lastMessageTs":[">",1679298371586.0],"subject":["oneOf",["Pink shoes",null]]}');
+  });
+
+  test('test MessagePredicate string', () {
+    expect(
+        json.encode(MessagePredicate(
+          custom: {
+            'seller': CustomFieldPredicate.exists(),
+            'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+            'visibility': CustomFieldPredicate.equals('visible'),
+          },
+          origin: FieldPredicate.equals(MessageOrigin.web),
+          sender: SenderPredicate(
+            id: FieldPredicate.notEquals('INVALID_ID'),
+            custom: {
+              'seller': CustomFieldPredicate.exists(),
+              'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+              'visibility': CustomFieldPredicate.equals('visible'),
+            },
+            locale: FieldPredicate.notOneOf(['it', 'fr']),
+            role: FieldPredicate.notEquals('admin'),
+          ),
+          type: FieldPredicate.notEquals(MessageType.systemMessage),
+        )),
+        '{"custom":{"seller":"exists","category":["oneOf",["shoes","sandals"]],"visibility":["==","visible"]},"origin":["==","web"],"sender":{"id":["!=","INVALID_ID"],"custom":{"seller":"exists","category":["oneOf",["shoes","sandals"]],"visibility":["==","visible"]},"locale":["!oneOf",["it","fr"]],"role":["!=","admin"]},"type":["!=","SystemMessage"]}');
+  });
+
+  test('test CompoundConversationPredicate', () {
+    expect(
+      json.encode(CompoundConversationPredicate.any([
+        ConversationPredicate(
+          access: FieldPredicate.notEquals(ConversationAccessLevel.none),
+          custom: {
+            'seller': CustomFieldPredicate.exists(),
+            'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+            'visibility': CustomFieldPredicate.equals('visible'),
+          },
+          hasUnreadMessages: false,
+          lastMessageTs: NumberPredicate.greaterThan(1679298371586),
+          subject: FieldPredicate.oneOf(['Pink shoes', null]),
         ),
-        type: FieldPredicate.notEquals(MessageType.systemMessage),
-      )),
-      '{"custom":{"seller":"exists","category":["oneOf",["shoes","sandals"]],"visibility":["==","visible"]},"origin":["==","web"],"sender":{"id":["!=","INVALID_ID"],"custom":{"seller":"exists","category":["oneOf",["shoes","sandals"]],"visibility":["==","visible"]},"locale":["!oneOf",["it","fr"]],"role":["!=","admin"]},"type":["!=","SystemMessage"]}'
+        ConversationPredicate(
+          access: FieldPredicate.notEquals(ConversationAccessLevel.none),
+          custom: {
+            'seller': CustomFieldPredicate.exists(),
+            'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+            'visibility': CustomFieldPredicate.equals('visible'),
+          },
+          hasUnreadMessages: false,
+          lastMessageTs: NumberPredicate.greaterThan(1679298371586),
+          subject: FieldPredicate.equals(null),
+        )
+      ])),
+      '["any",[{"access":["!=","None"],"custom":{"seller":"exists","category":["oneOf",["shoes","sandals"]],"visibility":["==","visible"]},"hasUnreadMessages":false,"lastMessageTs":[">",1679298371586.0],"subject":["oneOf",["Pink shoes",null]]},{"access":["!=","None"],"custom":{"seller":"exists","category":["oneOf",["shoes","sandals"]],"visibility":["==","visible"]},"hasUnreadMessages":false,"lastMessageTs":[">",1679298371586.0],"subject":["==",null]}]]',
+    );
+  });
+
+  test('test CompoundMessagePredicate', () {
+    expect(
+      json.encode(CompoundMessagePredicate.any([
+        MessagePredicate(
+          custom: {
+            'seller': CustomFieldPredicate.exists(),
+            'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+            'visibility': CustomFieldPredicate.equals('visible'),
+          },
+          origin: FieldPredicate.equals(MessageOrigin.web),
+          sender: SenderPredicate(
+            id: FieldPredicate.notEquals('INVALID_ID'),
+            custom: {
+              'seller': CustomFieldPredicate.exists(),
+              'category': CustomFieldPredicate.oneOf(['shoes', 'sandals']),
+              'visibility': CustomFieldPredicate.equals('visible'),
+            },
+            locale: FieldPredicate.notOneOf(['it', 'fr']),
+            role: FieldPredicate.notEquals('admin'),
+          ),
+          type: FieldPredicate.notEquals(MessageType.systemMessage),
+        ),
+        MessagePredicate(
+          origin: FieldPredicate.notEquals(MessageOrigin.web),
+          type: FieldPredicate.equals(MessageType.systemMessage),
+        ),
+      ])),
+      '["any",[{"custom":{"seller":"exists","category":["oneOf",["shoes","sandals"]],"visibility":["==","visible"]},"origin":["==","web"],"sender":{"id":["!=","INVALID_ID"],"custom":{"seller":"exists","category":["oneOf",["shoes","sandals"]],"visibility":["==","visible"]},"locale":["!oneOf",["it","fr"]],"role":["!=","admin"]},"type":["!=","SystemMessage"]},{"origin":["!=","web"],"type":["==","SystemMessage"]}]]',
     );
   });
 }
-


### PR DESCRIPTION
Recently TalkJS added the capability of specifying the `feedFilter` and `messageFilter` as `["any", [filter1, filter2, filter3]]`.
Given that Dart ~is a horrible language~ doesn't have union types, I implemented 2 abstract base classes `BaseConversationPredicate` and `BaseMessagePredicate`, each with 2 implementors: 1 is the classic `ConversationPredicate` and `MessagePredicagte` that was already there, and 1 is `CompoundConversationPredicate` and `CompoundMessagePredicate`, which implement the "any" filters.
The ChatBox and ConversationList accept the `Base*Predicate`s, so that existing code runs unmodified, and new code can use either of the 2 implementors.