### PR TITLE
(talkjs_flutter.dart): Remove requestNotificationPermissions

### DIFF
--- a/example/push_notifications/lib/main.dart
+++ b/example/push_notifications/lib/main.dart
@@ -1,13 +1,26 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:talkjs_flutter/talkjs_flutter.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // Request push notification permissions
-  await Talk.requestNotificationPermissions();
+  if (Platform.isAndroid) {
+    await FlutterLocalNotificationsPlugin()
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()!
+        .requestNotificationsPermission();
+  } else if (Platform.isIOS) {
+    await FlutterLocalNotificationsPlugin()
+        .resolvePlatformSpecificImplementation<
+            IOSFlutterLocalNotificationsPlugin>()!
+        .requestPermissions(sound: true, alert: true, badge: true);
+  }
 
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,

--- a/example/push_notifications/pubspec.lock
+++ b/example/push_notifications/pubspec.lock
@@ -175,7 +175,7 @@ packages:
     source: hosted
     version: "1.0.4"
   flutter_local_notifications:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_local_notifications
       sha256: c18f1de98fe0bb9dd5ba91e1330d4febc8b6a7de6aae3ffe475ef423723e72f3
@@ -448,10 +448,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher
-      sha256: c512655380d241a337521703af62d2c122bf7b77a46ff7dd750092aa9433499c
+      sha256: "0ecc004c62fd3ed36a2ffcbe0dd9700aee63bd7532d0b642a488b1ec310f492e"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.4"
+    version: "6.2.5"
   url_launcher_android:
     dependency: transitive
     description:
@@ -464,10 +464,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: "75bb6fe3f60070407704282a2d295630cab232991eb52542b18347a8a941df03"
+      sha256: "9149d493b075ed740901f3ee844a38a00b33116c7c5c10d7fb27df8987fb51d5"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.4"
+    version: "6.2.5"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -550,4 +550,4 @@ packages:
     version: "6.5.0"
 sdks:
   dart: ">=3.3.0-279.1.beta <4.0.0"
-  flutter: ">=3.16.0"
+  flutter: ">=3.16.6"

--- a/example/push_notifications/pubspec.yaml
+++ b/example/push_notifications/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
 
   talkjs_flutter:
     path: ../../
+  flutter_local_notifications: ^16.3.2
 
 dev_dependencies:
   flutter_test:

--- a/lib/talkjs_flutter.dart
+++ b/lib/talkjs_flutter.dart
@@ -4,8 +4,6 @@ import 'dart:convert' show json, utf8;
 import 'dart:io' show Platform;
 import 'package:crypto/crypto.dart' show sha1;
 import 'src/notification.dart';
-import 'package:flutter_apns_only/flutter_apns_only.dart';
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 export 'src/chatoptions.dart';
 export 'src/conversation.dart';
@@ -45,18 +43,5 @@ class Talk {
     if ((Platform.isIOS) && (iosSettings != null)) {
       await registerIOSPushNotificationHandlers(iosSettings);
     }
-  }
-
-  static Future<bool?> requestNotificationPermissions() async {
-    if (Platform.isAndroid) {
-      return FlutterLocalNotificationsPlugin()
-          .resolvePlatformSpecificImplementation<
-              AndroidFlutterLocalNotificationsPlugin>()!
-          .requestNotificationsPermission();
-    } else if (Platform.isIOS) {
-      return ApnsPushConnectorOnly().requestNotificationPermissions();
-    }
-
-    return null;
   }
 }


### PR DESCRIPTION
After further discussion in Slack, it was decided that we would revert the addition of requestNotificationPermissions.