### PR TITLE
(chore) Relaxed version requirements for the http package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1
+
+- Relaxed version requirements for the Dart SDK and http packages
+
 ## 0.10.0
 
 - Add support for Firebase push notifications on iOS.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   firebase_core: ^2.25.4
   firebase_messaging: ^14.7.15
   flutter_local_notifications: ^16.3.2
-  http: '>=0.13.6'
+  http: '>=0.13.6 <2.0.0'
   flutter_apns_only: ^1.6.0
   permission_handler: ^11.0.1
   url_launcher: ^6.1.11

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.10.0
 homepage: https://talkjs.com
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=2.18.0 <4.0.0'
   flutter: '>=2.8.1'
 
 platforms:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talkjs_flutter
 description: Official TalkJS SDK for Flutter
-version: 0.10.0
+version: 0.10.1
 homepage: https://talkjs.com
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   firebase_core: ^2.25.4
   firebase_messaging: ^14.7.15
   flutter_local_notifications: ^16.3.2
-  http: ^0.13.6
+  http: '>=0.13.6'
   flutter_apns_only: ^1.6.0
   permission_handler: ^11.0.1
   url_launcher: ^6.1.11


### PR DESCRIPTION
Fixes #52 

We only use the http package in the simplest form, with a get and an URL, and nothing more, so it's safe to relax the version requirement for it, so that our customers can use the http package version they want.