### PR TITLE
Fix buggy MessageFieldOptions

### DIFF
--- a/lib/src/chatoptions.dart
+++ b/lib/src/chatoptions.dart
@@ -63,15 +63,15 @@ class MessageFieldOptions {
       }
     }
 
-    if (autofocus != null) {
+    if (enterSendsMessage != null) {
       result['enterSendsMessage'] = enterSendsMessage;
     }
 
-    if (autofocus != null) {
+    if (placeholder != null) {
       result['placeholder'] = placeholder;
     }
 
-    if (autofocus != null) {
+    if (spellcheck != null) {
       result['spellcheck'] = spellcheck;
     }
 


### PR DESCRIPTION
Fixes #29

Assigning the `messageField` property to the ChatBox didn't pass the correct options to the JS SDK.
This PR fixes that.