### PR TITLE
Added Talk.initPushNotificationHandlers and Talk.handleFCMBackgroundMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.15.0
 
-- Add `registerBackgroundHandler` property to AndroidOptions
+- Add `registerBackgroundHandler` property to AndroidSettings passed to `registerPushNotificationHandlers()`
 - Add `Talk.handleFCMBackgroundMessage` function
 
 ## 0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.15.0
+
+- Add `registerBackgroundHandler` property to AndroidOptions
+- Add `Talk.handleFCMBackgroundMessage` function
+
 ## 0.14.0
 
 - Add `onUnreadsChange` property to Session

--- a/example/push_notifications/pubspec.lock
+++ b/example/push_notifications/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_jsonwebtoken
-      sha256: adf073720e491d64fa599942615b919915710af2d809b2798146f9b7c4330f3f
+      sha256: "866787dc17afaef46a9ea7dd33eefe60c6d82084b4a36d70e8e788d091cd04ef"
       url: "https://pub.dev"
     source: hosted
-    version: "2.14.1"
+    version: "2.14.2"
   dbus:
     dependency: transitive
     description:
@@ -210,42 +210,42 @@ packages:
     dependency: transitive
     description:
       name: flutter_inappwebview_internal_annotations
-      sha256: "5f80fd30e208ddded7dbbcd0d569e7995f9f63d45ea3f548d8dd4c0b473fb4c8"
+      sha256: "787171d43f8af67864740b6f04166c13190aa74a1468a1f1f1e9ee5b90c359cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: b543301ad291598523947dc534aaddc5aaad597b709d2426d3a0e0d44c5cb493
+      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "5.0.0"
   flutter_local_notifications:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "674173fd3c9eda9d4c8528da2ce0ea69f161577495a9cc835a2a4ecd7eadeb35"
+      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.4"
+    version: "18.0.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
+      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
+      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "8.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -308,10 +308,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: a2c3d198cb5ea2e179926622d433331d8b58374ab8f29cdda6e863bd62fd369c
+      sha256: "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "5.0.0"
   matcher:
     dependency: transitive
     description:
@@ -396,10 +396,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: af26edbbb1f2674af65a8f4b56e1a6f526156bc273d0e65dd8075fab51c78851
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+2"
+    version: "0.1.3+5"
   permission_handler_platform_interface:
     dependency: transitive
     description:
@@ -460,10 +460,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
+      sha256: "7f172d1b06de5da47b6264c2692ee2ead20bbbc246690427cdb4fc301cd0c549"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.4"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -576,10 +576,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      sha256: ffc9d5f4d1193534ef051f9254063fa53d588609418c84299956c3db9383587d
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4"
+    version: "0.10.0"
   typed_data:
     dependency: transitive
     description:

--- a/example/push_notifications/pubspec.yaml
+++ b/example/push_notifications/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
 
   talkjs_flutter:
     path: ../../
-  flutter_local_notifications: ^17.1.2
+  flutter_local_notifications: ^18.0.1
   dart_jsonwebtoken: ^2.14.1
 
 dev_dependencies:
@@ -48,7 +48,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^1.0.0
+  flutter_lints: ^5.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/talkjs_flutter.dart
+++ b/lib/talkjs_flutter.dart
@@ -34,14 +34,27 @@ class Talk {
     return hash.substring(0, 20);
   }
 
-  static Future<void> registerPushNotificationHandlers(
-      {AndroidSettings? androidSettings, IOSSettings? iosSettings}) async {
+  static Future<void> registerPushNotificationHandlers({
+    AndroidSettings? androidSettings,
+    IOSSettings? iosSettings,
+  }) async {
     if ((Platform.isAndroid) && (androidSettings != null)) {
       await registerAndroidPushNotificationHandlers(androidSettings);
-    }
-
-    if ((Platform.isIOS) && (iosSettings != null)) {
+    } else if ((Platform.isIOS) && (iosSettings != null)) {
       await registerIOSPushNotificationHandlers(iosSettings);
     }
   }
+
+  static Future<void> initPushNotificationHandlers({
+    AndroidSettings? androidSettings,
+    IOSSettings? iosSettings,
+  }) async {
+    if ((Platform.isAndroid) && (androidSettings != null)) {
+      await initAndroidPushNotificationHandlers(androidSettings);
+    } else if ((Platform.isIOS) && (iosSettings != null)) {
+      await initIOSPushNotificationHandlers(iosSettings);
+    }
+  }
+
+  static const handleFCMBackgroundMessage = handleTalkJSFCMBackgroundMessage;
 }

--- a/lib/talkjs_flutter.dart
+++ b/lib/talkjs_flutter.dart
@@ -45,16 +45,5 @@ class Talk {
     }
   }
 
-  static Future<void> initPushNotificationHandlers({
-    AndroidSettings? androidSettings,
-    IOSSettings? iosSettings,
-  }) async {
-    if ((Platform.isAndroid) && (androidSettings != null)) {
-      await initAndroidPushNotificationHandlers(androidSettings);
-    } else if ((Platform.isIOS) && (iosSettings != null)) {
-      await initIOSPushNotificationHandlers(iosSettings);
-    }
-  }
-
   static const handleFCMBackgroundMessage = handleTalkJSFCMBackgroundMessage;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -178,34 +178,34 @@ packages:
     dependency: transitive
     description:
       name: flutter_inappwebview_internal_annotations
-      sha256: "5f80fd30e208ddded7dbbcd0d569e7995f9f63d45ea3f548d8dd4c0b473fb4c8"
+      sha256: "787171d43f8af67864740b6f04166c13190aa74a1468a1f1f1e9ee5b90c359cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   flutter_local_notifications:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "674173fd3c9eda9d4c8528da2ce0ea69f161577495a9cc835a2a4ecd7eadeb35"
+      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
       url: "https://pub.dev"
     source: hosted
-    version: "17.2.4"
+    version: "18.0.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: c49bd06165cad9beeb79090b18cd1eb0296f4bf4b23b84426e37dd7c027fc3af
+      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "85f8d07fe708c1bdcf45037f2c0109753b26ae077e9d9e899d55971711a4ea66"
+      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "8.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -284,10 +284,10 @@ packages:
     dependency: "direct dev"
     description:
       name: lint_staged
-      sha256: "8ebeb6c1f6d76dff550f827f0051026a5127b90a88e7cdd5fc009144b77d57c3"
+      sha256: "969cb1829d5f5ca761dd9029762ab11e73bf83bc270a2ea03297c60eed261e3e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.3"
+    version: "0.5.1"
   matcher:
     dependency: transitive
     description:
@@ -372,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: af26edbbb1f2674af65a8f4b56e1a6f526156bc273d0e65dd8075fab51c78851
+      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+2"
+    version: "0.1.3+5"
   permission_handler_platform_interface:
     dependency: transitive
     description:
@@ -428,10 +428,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "3b9febd815c9ca29c9e3520d50ec32f49157711e143b7a4ca039eb87e8ade5ab"
+      sha256: "7f172d1b06de5da47b6264c2692ee2ead20bbbc246690427cdb4fc301cd0c549"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.3.4"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -537,10 +537,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      sha256: ffc9d5f4d1193534ef051f9254063fa53d588609418c84299956c3db9383587d
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.4"
+    version: "0.10.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: talkjs_flutter
 description: Official TalkJS SDK for Flutter
-version: 0.14.0
+version: 0.15.0
 homepage: https://talkjs.com
 
 environment:
@@ -19,7 +19,7 @@ dependencies:
   crypto: ^3.0.3
   firebase_core: ^3.1.0
   firebase_messaging: ^15.0.1
-  flutter_local_notifications: ^17.1.2
+  flutter_local_notifications: ^18.0.1
   http: '>=0.13.6 <2.0.0'
   flutter_apns_only: ^1.6.0
   permission_handler: ^11.3.1
@@ -30,7 +30,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   husky: ^0.1.6
-  lint_staged: ^0.4.2
+  lint_staged: ^0.5.1
 
 lint_staged:
   '**/*.dart': dart format && dart fix --apply


### PR DESCRIPTION
See https://talkjs.slack.com/archives/C02PH434FAT/p1733135037788469

This PR adds the `registerBackgroundHandler` option to the `AndroidSettings` that allows to not register the background handler (defaults to `true`).

It also adds the `Talk.handleFCMBackgroundMessage` function, that is to be called inside a background notification handler.

```dart
import 'package:flutter/material.dart';
import 'package:talkjs_flutter/talkjs_flutter.dart';
import 'package:firebase_core/firebase_core.dart';
import 'package:firebase_messaging/firebase_messaging.dart';
import 'firebase_options.dart';

Future<void> main() async {
  WidgetsFlutterBinding.ensureInitialized();

  if (Platform.isAndroid) {
    await Firebase.initializeApp(
      options: DefaultFirebaseOptions.currentPlatform,
    );
  }

  await Talk.registerPushNotificationHandlers(
    androidSettings: const AndroidSettings(
      channelId: 'com.example.talkjsflutter.messages',
      channelName: 'Messages',
      registerBackgroundHandler: false,
    ),
    iosSettings: const IOSSettings(useFirebase: false),
  );

  FirebaseMessaging.onBackgroundMessage(myBackgroundMessageHandler);

  runApp(const MyApp());
}

@pragma("vm:entry-point")
Future<void> myBackgroundMessageHandler(RemoteMessage firebaseMessage) async {
  // Call the TalkJS-specific push notification handler
  final notificationHandled = await Talk.handleFCMBackgroundMessage(firebaseMessage);

  if (!notificationHandled) {
    // Handle non-TalkJS originated push notification
  }
}

```