### PR TITLE
(Chore): GitHub action publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       # must align with the tag-pattern configured on pub.dev
       # tag-pattern on pub.dev: 'v{{version}}'
       # where {{version}} is identical to what we have in pubspec.yaml
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   publishing:


### PR DESCRIPTION
These changes are aimed at improving the securing the package publishing process. The main change is the use of short-lived OIDC tokens signed by Github instead of longlived tokens.

Also as part of this change is the enforcement of the use of commit SHAs instead of version numbers for 3rd party actions used. This helps prevent any supply chain attacks that may occur in future.
